### PR TITLE
More progressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+public/build

--- a/spec/lib/Bar.spec.js
+++ b/spec/lib/Bar.spec.js
@@ -8,7 +8,7 @@ it('determines current chord', () => {
 
   let bar1 = sw.sectionA.lines[0].bars[0]
   bar1.chooseNotes()
-  expect(bar1.firstNote()).toEqual('D2')
+  expect(bar1.firstNote()).toEqual('D3')
   expect(bar1.lastNote()).not.toBe(null)
 
   let bar2 = sw.sectionA.lines[0].bars[1]
@@ -26,7 +26,7 @@ it('determines notes', () => {
 
   let bar1 = sw.sectionA.lines[0].bars[0]
   bar1.chooseNotes()
-  expect(bar1.chosenFirstNote).toEqual('D2')
+  expect(bar1.chosenFirstNote).toEqual('D3')
   expect(bar1.chosenNotesBetween.length).toEqual(2)
 
   let bar2 = sw.sectionA.lines[0].bars[1]
@@ -44,7 +44,7 @@ it('determines notes while changing chord', () => {
 
   let bar1 = sw.sectionA.lines[0].bars[0]
   bar1.chooseNotes()
-  expect(bar1.chosenFirstNote).toEqual('D2')
+  expect(bar1.chosenFirstNote).toEqual('D3')
   expect(bar1.chosenNotesBetween.length).toEqual(2)
 
   let bar2 = sw.sectionA.lines[0].bars[1]

--- a/spec/lib/NoteChooser.spec.js
+++ b/spec/lib/NoteChooser.spec.js
@@ -17,7 +17,7 @@ let setRandom = function(val) {
 
 it('passes through first note', () => {
   let nc = prep('C7', 'C7', 'C2', 'C')
-  expect(nc.firstNote()).toEqual('C3')
+  expect(nc.firstNote()).toEqual('C2')
 })
 
 it('chooses obvious first note', () => {

--- a/spec/lib/NoteChooser.spec.js
+++ b/spec/lib/NoteChooser.spec.js
@@ -29,12 +29,12 @@ it('chooses last note', () => {
   setRandom(0)
   let nc = prep('C7', 'C7', null, 'C', 'down')
   expect(nc.firstNote()).toEqual('C3')
-  expect(nc.lastNote()).toEqual('B0')
+  expect(nc.lastNote()).toEqual('B1')
 
   setRandom(0.65)
   nc = prep('C7', 'C7', null, 'C')
   expect(nc.firstNote()).toEqual('C3')
-  expect(nc.lastNote()).toEqual('A#1')
+  expect(nc.lastNote()).toEqual('A#2')
 })
 
 it('next bar first note', () => {
@@ -45,10 +45,10 @@ it('next bar first note', () => {
 
   nc = prep('C7', 'C7', null, 'C', 'down')
   expect(nc.firstNote()).toEqual('C3')
-  expect(nc.runNextBarFirstNote()).toEqual('B1')
+  expect(nc.runNextBarFirstNote()).toEqual('B2')
 
   setRandom(0.5)
   nc = prep('Dm7', 'Dm7', null, 'C', 'down')
   expect(nc.firstNote()).toEqual('D3')
-  expect(nc.runNextBarFirstNote()).toEqual('D1')
+  expect(nc.runNextBarFirstNote()).toEqual('D2')
 })

--- a/spec/lib/NoteChooser.spec.js
+++ b/spec/lib/NoteChooser.spec.js
@@ -17,38 +17,38 @@ let setRandom = function(val) {
 
 it('passes through first note', () => {
   let nc = prep('C7', 'C7', 'C2', 'C')
-  expect(nc.firstNote()).toEqual('C2')
+  expect(nc.firstNote()).toEqual('C3')
 })
 
 it('chooses obvious first note', () => {
   let nc = prep('C7', 'C7', null, 'C')
-  expect(nc.firstNote()).toEqual('C2')
+  expect(nc.firstNote()).toEqual('C3')
 })
 
 it('chooses last note', () => {
   setRandom(0)
   let nc = prep('C7', 'C7', null, 'C', 'down')
-  expect(nc.firstNote()).toEqual('C2')
+  expect(nc.firstNote()).toEqual('C3')
   expect(nc.lastNote()).toEqual('B0')
 
   setRandom(0.65)
   nc = prep('C7', 'C7', null, 'C')
-  expect(nc.firstNote()).toEqual('C2')
+  expect(nc.firstNote()).toEqual('C3')
   expect(nc.lastNote()).toEqual('A#1')
 })
 
 it('next bar first note', () => {
   setRandom(0.99)
   let nc = prep('C7', 'C7', null, 'C', 'up')
-  expect(nc.firstNote()).toEqual('C2')
-  expect(nc.runNextBarFirstNote()).toEqual('D2')
+  expect(nc.firstNote()).toEqual('C3')
+  expect(nc.runNextBarFirstNote()).toEqual('D3')
 
   nc = prep('C7', 'C7', null, 'C', 'down')
-  expect(nc.firstNote()).toEqual('C2')
+  expect(nc.firstNote()).toEqual('C3')
   expect(nc.runNextBarFirstNote()).toEqual('B1')
 
   setRandom(0.5)
   nc = prep('Dm7', 'Dm7', null, 'C', 'down')
-  expect(nc.firstNote()).toEqual('D2')
+  expect(nc.firstNote()).toEqual('D3')
   expect(nc.runNextBarFirstNote()).toEqual('D1')
 })

--- a/src/lib/Section.js
+++ b/src/lib/Section.js
@@ -38,7 +38,7 @@ class Section {
 
   generateChordsToBars() {
     if (this.lineCount == 2) {
-      if (this.progression.length == 3) { return [4, 2, 2] }
+      if (this.progression.length == 3) { return [2, 2, 4] }
       if (this.progression.length == 4) { return [2, 2, 2, 2] }
       if (this.progression.length == 6) { return [2, 2, 1, 1, 1, 1] }
     }

--- a/src/lib/musicUtils.js
+++ b/src/lib/musicUtils.js
@@ -40,8 +40,14 @@ const progressions = [
   ['IMaj7', 'VIm7', 'IIm7', 'V7'],
   ['IIm7', 'VI7', 'IIm7', 'V7'],
   ['IMaj7', 'IMaj7', 'IIm7', 'V7'],
-  ['Imaj7', 'IIm7', 'V7', 'IVmaj7']
-]
+  ['Imaj7', 'IIm7', 'V7', 'IVmaj7'],
+  ["Imaj7", "bIIo7", "IIm7", "bIIIo7"], 
+  ["IIIm7", "IVMaj7", "bVo7", "V7"],
+  ["IMaj7", "bIII7", "IIm7", "bII7" ],
+  ["IMaj7", "bIII7", "bVI7", "bII7"],
+  ["IMaj7", "IMaj7", "II7", "II7"],
+  ["IMaj7", "Im7", "II7", "bIIMaj7"]
+];
 
 function prepProgression(prog) {
   let res = []

--- a/src/lib/musicUtils.js
+++ b/src/lib/musicUtils.js
@@ -41,12 +41,13 @@ const progressions = [
   ['IIm7', 'VI7', 'IIm7', 'V7'],
   ['IMaj7', 'IMaj7', 'IIm7', 'V7'],
   ['Imaj7', 'IIm7', 'V7', 'IVmaj7'],
-  ["Imaj7", "bIIo7", "IIm7", "bIIIo7"], 
-  ["IIIm7", "IVMaj7", "bVo7", "V7"],
-  ["IMaj7", "bIII7", "IIm7", "bII7" ],
-  ["IMaj7", "bIII7", "bVI7", "bII7"],
-  ["IMaj7", "IMaj7", "II7", "II7"],
-  ["IMaj7", "Im7", "II7", "bIIMaj7"]
+  ['Imaj7', 'bIIo7', 'IIm7', 'bIIIo7'],
+  ['IIIm7', 'IVMaj7', 'bVo7', 'V7'],
+  ['IMaj7', 'bIII7', 'IIm7', 'bII7'],
+  ['IIIm7', 'bIII7', 'IIm7', 'bII7'],
+  ['IMaj7', 'bIII7', 'bVI7', 'bII7'],
+  ['IMaj7', 'II7', 'IIm7', 'V7'],
+  ['IMaj7', 'Im7', 'II7', 'bIIMaj7']
 ];
 
 function prepProgression(prog) {

--- a/src/lib/musicUtils.js
+++ b/src/lib/musicUtils.js
@@ -4,7 +4,7 @@ import * as Tonal from '@tonaljs/tonal'
 window.t = Tonal
 const acceptableScales = ["major", "minor", 'minor pentatonic',
   'major blues', 'minor blues', 'harmonic minor', 'melodic minor', 'bebop', 'bebop minor', 'bebop major',
-  'minor bebop']
+  'minor bebop', 'diminished']
 // const acceptableScales = ['bebop']
 
 function chooseScale(chord) {


### PR DESCRIPTION
Starting small, I just added some new progressions and a scale.

## Progressions
* added some variations on I, VI, II, V
* added a version of the ascending chromatic progression, split into 2 separate arrays:  `['IMaj7', 'bIIo7', 'IIm7', 'bIIIo7']` and `['IIIm7', 'IVMaj7', 'bVo7', 'V7']`
* added the progression from the first four bars of 'On Green Dolphin Street': `['Imaj7', 'Im7', 'II7', 'bIIMaj7']`
* added 'diminished' to acceptableScales so it can be used over 'o7' chords

## Tests
 NoteChooser.spec.js and Bar.spec.js were failing (even on master) and I think it was because you pushed notes up an octave in 8357fe8de1d46c3136f15cdeafaa724e8944de10 and never updated the tests to match. I updated those two tests. If I interpreted this incorrectly, I'll change them back. All other tests passed before the change.

## generateChordsToBars 
If an A section progression array has only three chords I swapped the return order to `[2, 2, 4]` because the only one with three was  `['IIm7', 'V7', 'IMaj7']` and that's typically the chord-length ratio of it in most Jazz standards.

I also had to add a .gitignore file because there wasn't one present in the repo. I'm not sure how much of a problem that will be.

